### PR TITLE
fixed require modules out of scope

### DIFF
--- a/ch4.md
+++ b/ch4.md
@@ -126,7 +126,6 @@ Let's acquire another essential tool called `compose`.
 ## Exercises
 
 ```js
-require('../../support')
 var _ = require('ramda')
 
 


### PR DESCRIPTION
require('../../support') 
also with new lodash code:

line 47:
```
var map = curry(function(f, xs) {
  return xs.map(f);
})
```
```var map = _.curry(_.map)```
there is also helper _.curryRight