### PR TITLE
Fix memoize example

### DIFF
--- a/ch3.md
+++ b/ch3.md
@@ -153,7 +153,7 @@ var memoize = function(f) {
   var cache = {};
 
   return function() {
-    var arg_str = String(arguments);
+    var arg_str = JSON.stringify(arguments);
     cache[arg_str] = cache[arg_str] || f.apply(f, arguments);
     return cache[arg_str];
   };


### PR DESCRIPTION
`String(arguments)` will return `[object Arguments]` which in turn will return the same result for every argument.

Using `JSON.stringify` is an easy alternative solution.