### PR TITLE
Removing unused argument

### DIFF
--- a/ch8.md
+++ b/ch8.md
@@ -96,7 +96,7 @@ Maybe.of = function(x) {
   return new Maybe(x);
 }
 
-Maybe.prototype.isNothing = function(f) {
+Maybe.prototype.isNothing = function() {
   return (this.__value === null || this.__value === undefined);
 }
 


### PR DESCRIPTION
Passing an unnecessary argument to `isNothing()`