### PR TITLE
Update log :: String -> IO String

### DIFF
--- a/ch9.md
+++ b/ch9.md
@@ -125,7 +125,7 @@ IO.prototype.join = function() {
 Again, we simply remove one layer. Mind you, we have not thrown out purity, but merely removed one layer of excess shrink wrap.
 
 ```js
-//  log :: String -> IO String
+//  log :: String -> IO ()
 var log = function(s) {
   return new IO(function() { return console.log(s); });
 }


### PR DESCRIPTION
`log :: String -> IO String` to `log :: String -> IO ()`
`console.log` returns `undefined ` which I think is better represented by `()`

Which mean that log should be moved furthest to the left in the composed function or change the implementation of `log` to return the string e.g.

```js
// log :: String -> IO String`
 var log = function(s) {
   return new IO(function() { console.log(s); return s; });
 }
```
I will update the PR when I know how to progress.