### PR TITLE
Align types in join example

### DIFF
--- a/ch9.md
+++ b/ch9.md
@@ -127,7 +127,7 @@ Again, we simply remove one layer. Mind you, we have not thrown out purity, but 
 ```js
 //  log :: a -> IO a
 var log = function(x) {
-  return new IO(function() { console.log(s); return x; });
+  return new IO(function() { console.log(x); return x; });
 }
 
 //  setStyle :: Selector -> CSSProps -> IO DOM

--- a/ch9.md
+++ b/ch9.md
@@ -125,22 +125,14 @@ IO.prototype.join = function() {
 Again, we simply remove one layer. Mind you, we have not thrown out purity, but merely removed one layer of excess shrink wrap.
 
 ```js
-// tap :: (a -> b) -> a -> a
-var tap = curry(function(f, it) { f(it); return it; });
+//  log :: a -> IO a
+var log = function(x) {
+  return new IO(function() { console.log(s); return x; });
+}
 
-//  log :: Object -> IO Object
-var log = function(o) {
-  return new IO(function() { console.log(o); return o; });
-};
-
-//  setStyles :: Selector -> CSSProps -> IO DOM
-var setStyles = curry(function(sel, props) {
-  return new IO(function() {
-    return tap(
-      function(dom) { map(function(key) { dom.style[key] = props[key]; }, Object.keys(props)); },
-      $(el)
-    );
-  });
+//  setStyle :: Selector -> CSSProps -> IO DOM
+var setStyle = curry(function(sel, props) {
+  return new IO(function() { return jQuery(sel).css(props); });
 });
 
 //  getItem :: String -> IO String

--- a/ch9.md
+++ b/ch9.md
@@ -125,31 +125,39 @@ IO.prototype.join = function() {
 Again, we simply remove one layer. Mind you, we have not thrown out purity, but merely removed one layer of excess shrink wrap.
 
 ```js
-//  log :: String -> IO ()
-var log = function(s) {
-  return new IO(function() { return console.log(s); });
-}
+// tap :: (a -> b) -> a -> a
+var tap = curry(function(f, it) { f(it); return it; });
 
-//  setStyle :: Selector -> CSSProps -> IO DOM
-var setStyle = curry(function(sel, props) {
-  return new IO(function() { return $(sel).style(props); });
-})
+//  log :: Object -> IO Object
+var log = function(o) {
+  return new IO(function() { console.log(o); return o; });
+};
+
+//  setStyles :: Selector -> CSSProps -> IO DOM
+var setStyles = curry(function(sel, props) {
+  return new IO(function() {
+    return tap(
+      function(dom) { map(function(key) { dom.style[key] = props[key]; }, Object.keys(props)); },
+      $(el)
+    );
+  });
+});
 
 //  getItem :: String -> IO String
 var getItem = function(key) {
   return new IO(function() { return localStorage.getItem(key); });
-}
+};
 
 //  applyPreferences :: String -> IO DOM
 var applyPreferences = compose(join, map(setStyle('#main')), join, map(log), map(JSON.parse), getItem);
 
 
 applyPreferences('preferences').unsafePerformIO();
-// "{backgroundColor: 'green'}"
+// Object {backgroundColor: "green"}
 // <div style="background-color: 'green'"/>
 ```
 
-`getItem` returns an `IO JSON` so we `map` to parse it. Both `log` and `setStyle` return `IO`'s themselves so we must `join` to keep our nesting under control.
+`getItem` returns an `IO String` so we `map` to parse it. Both `log` and `setStyle` return `IO`'s themselves so we must `join` to keep our nesting under control.
 
 ## My chain hits my chest
 


### PR DESCRIPTION
This should be runnable (havn't tried). 

CSSProps to Object, readers might not be aware of type aliases at this point.

Added tap to make a runnable `setStyles` example. It might be better to remove it and use an `interim` variable if its confusing for readers.