### PR TITLE
Explicitly point readers to the unit tests

### DIFF
--- a/ch4.md
+++ b/ch4.md
@@ -130,6 +130,8 @@ A quick word before we start. We'll use a library called *ramda* which curries e
 [ramda](http://ramdajs.com)
 [lodash-fp](https://github.com/lodash/lodash-fp)
 
+There are [unit tests](https://github.com/DrBoolean/mostly-adequate-guide/tree/master/code/part1_exercises) to run against your exercises as you code them, or you can just copy-paste into a javascript REPL for the early exercises if you wish.
+
 Answers are provided with the code in the [repository for this book](https://github.com/DrBoolean/mostly-adequate-guide/tree/master/code/part1_exercises/answers)
 
 ```js


### PR DESCRIPTION
Readers may not realize that there are unit tests available to run against the exercises, so we could point this out to them at the start of the first set of exercises.