### PR TITLE
Fix small typo

### DIFF
--- a/ch7.md
+++ b/ch7.md
@@ -65,7 +65,7 @@ var match = curry(function(reg, s){
 });
 ```
 
-Ah yes, grouping the last part in parenthesis reveals more information. Now it is seen a function that takes a `Regex` and returns us a function from `String` to `[String]`. Because of currying, this is indeed the case: give it a `Regex` and we get a function back waiting for its `String` argument. Of course, we don't have to think of it this way, but it is good to understand why the last type is the one returned.
+Ah yes, grouping the last part in parenthesis reveals more information. Now it is seen as a function that takes a `Regex` and returns us a function from `String` to `[String]`. Because of currying, this is indeed the case: give it a `Regex` and we get a function back waiting for its `String` argument. Of course, we don't have to think of it this way, but it is good to understand why the last type is the one returned.
 
 ```js
 //  match :: Regex -> (String -> [String])


### PR DESCRIPTION
Fixes #116, a small typo:

`Now it is seen a function`
becomes
`Now it is seen as a function`