### PR TITLE
Just a minor change

### DIFF
--- a/ch8.md
+++ b/ch8.md
@@ -162,9 +162,8 @@ Sometimes a function might return a `Maybe(null)` explicitly to signal failure. 
 //  withdraw :: Number -> Account -> Maybe(Account)
 var withdraw = curry(function(amount, account) {
   return account.balance >= amount ?
-    Maybe.of({balance: account.balance - amount})
-    :
-    Maybe.of(null);
+    Maybe.of({balance: account.balance - amount}) :  
+     Maybe.of(null);
 });
 
 //  finishTransaction :: Account -> String


### PR DESCRIPTION
Moved the colon up one line. That separate colon all alone on one line confused me for a moment. I think it's better to have it right after `Maybe.of({balance: account.balance - amount})`